### PR TITLE
Country name tooltip position

### DIFF
--- a/iframe-pym-tests-rtl.html
+++ b/iframe-pym-tests-rtl.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <style>
+    body {
+      margin: 0;
+      border: 0;
+      padding: 1em;
+      font-family: sans-serif;
+    }
+
+    h1 {
+      margin: 0 0 .5em;
+      font-size: 2em;
+      line-height: 1;
+      text-transform: uppercase;
+    }
+
+    p {
+      margin: 0 0 1em;
+      line-height: 1;
+    }
+
+    .map-wrapper {
+      margin: 0 0 1em;
+      padding: 1em;
+      background: #222;
+      color: #fff;
+    }
+
+    .map-wrapper h2 {
+      margin: 0 0 1em;
+      font-size: 100%;
+      line-height: 1;
+      font-weight: bold;
+      text-transform: uppercase;
+    }
+  </style>
+
+  <title>Embedding the map using Pym at different widths</title>  
+</head>
+
+<body>
+  <h1>Embedding the map using Pym at different widths</h1>
+
+  <p>Note: this page may take some time to load.</p>
+
+  <div class="map-wrapper" style="width:320px;">
+    <h2>320 pixels wide</h2>
+
+    <div id="map-embed-320"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:375px;">
+    <h2>375 pixels wide</h2>
+
+    <div id="map-embed-375"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:414px;">
+    <h2>414 pixels wide</h2>
+
+    <div id="map-embed-414"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:568px;">
+    <h2>568 pixels wide</h2>
+
+    <div id="map-embed-568"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:667px;">
+    <h2>667 pixels wide</h2>
+
+    <div id="map-embed-667"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:736px;">
+    <h2>736 pixels wide</h2>
+
+    <div id="map-embed-736"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:768px;">
+    <h2>768 pixels wide</h2>
+
+    <div id="map-embed-768"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:1024px;">
+    <h2>1024 pixels wide</h2>
+
+    <div id="map-embed-1024"></div>
+  </div>
+
+  <div class="map-wrapper" style="width:1366px;">
+    <h2>1366 pixels wide</h2>
+
+    <div id="map-embed-1366"></div>
+  </div>
+
+
+  <script type="text/javascript" src="javascripts/vendor/pym.js"></script>
+  <script>
+    var pymParent320  = new pym.Parent('map-embed-320',  'index.html?lang=ar', {});
+    var pymParent375  = new pym.Parent('map-embed-375',  'index.html?lang=ar', {});
+    var pymParent414  = new pym.Parent('map-embed-414',  'index.html?lang=ar', {});
+    var pymParent568  = new pym.Parent('map-embed-568',  'index.html?lang=ar', {});
+    var pymParent667  = new pym.Parent('map-embed-667',  'index.html?lang=ar', {});
+    var pymParent736  = new pym.Parent('map-embed-736',  'index.html?lang=ar', {});
+    var pymParent768  = new pym.Parent('map-embed-768',  'index.html?lang=ar', {});
+    var pymParent1024 = new pym.Parent('map-embed-1024', 'index.html?lang=ar', {});
+    var pymParent1366 = new pym.Parent('map-embed-1366', 'index.html?lang=ar', {});
+  </script>
+</body>
+
+</html>

--- a/javascripts/amnesty.js
+++ b/javascripts/amnesty.js
@@ -363,24 +363,16 @@ function draw(topo, activeCountries, coastline, somalilandBorder, kosovoBorder, 
       .attr("class","disputed-boundary")
       .attr("d", path);
 
-  if (dir === "rtl") {
-    tooltipOffset = -20;
-  }
-
-  else {
-    tooltipOffset = -250;
-  }
-
-  //ofsets plus width/height of transform, plus 20 px of padding, plus 20 extra for tooltip offset off mouse
-  var offsetL = document.getElementById('map').offsetLeft+tooltipOffset;
-  var offsetT =document.getElementById('map').offsetTop+(height/40);
-
   activeCountry
     .on("mousemove", function(d,i) {
         var mouse = d3.mouse(svg.node()).map( function(d) { return parseInt(d); } );
+
+        var xPositionProperty = (dir === "rtl" ? "right" : "left");
+        var xPositionValue = (dir === "rtl" ? width-mouse[0]+15 : mouse[0]+15);
+
           tooltip
             .classed("hidden", false)
-            .attr("style", "left:"+(mouse[0]+offsetL)+"px;top:"+(mouse[1]+offsetT)+"px")
+            .attr("style", xPositionProperty+":"+xPositionValue+"px;top:"+(mouse[1]+15)+"px")
             .html('<div class="title-text">'+ dictionary.getTranslation(d.name) + '</div>');
         })
         .on("mouseout",  function(d,i) {


### PR DESCRIPTION
Corrects position of country name tooltips, and makes them appear to the left of the mouse pointer in RTL mode (like the bar graph tooltips). See #58.